### PR TITLE
feat: 메인 & 로그인 & 회원가입 페이지 구현

### DIFF
--- a/BE/src/main/java/com/example/StudyBoard/global/config/SecurityConfig.java
+++ b/BE/src/main/java/com/example/StudyBoard/global/config/SecurityConfig.java
@@ -8,6 +8,11 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.cors.CorsConfiguration;
+import java.util.List;
+
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
@@ -17,10 +22,25 @@ public class SecurityConfig {
         return new BCryptPasswordEncoder(); // 비밀번호 암호화 도구 (BCrypt)
     }
 
+ // CORS 설정 추가
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+        config.setAllowedOriginPatterns(List.of("http://localhost:*")); // 프론트 주소
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        config.setAllowedHeaders(List.of("*"));
+        config.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+        return source;
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
+                //CORS 적용
+                .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable()) // 테스트 + API 서버 필수
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(

--- a/FE/package-lock.json
+++ b/FE/package-lock.json
@@ -55,7 +55,6 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1430,7 +1429,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1472,7 +1470,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1578,7 +1575,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1813,7 +1809,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2500,7 +2495,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2562,7 +2556,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2572,7 +2565,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2841,7 +2833,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -2963,7 +2954,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/FE/src/pages/LoginPage.jsx
+++ b/FE/src/pages/LoginPage.jsx
@@ -1,11 +1,118 @@
-import React from 'react';
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import "./auth.css";
+
+const API_BASE_URL = "http://localhost:8080";
 
 function LoginPage() {
+  const navigate = useNavigate();
+
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+
+  const [loading, setLoading] = useState(false);
+  const [errorMsg, setErrorMsg] = useState("");
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setErrorMsg("");
+
+    if (!email.trim() || !password.trim()) {
+      setErrorMsg("이메일과 비밀번호를 입력해주세요.");
+      return;
+    }
+
+    try {
+      setLoading(true);
+
+      const res = await fetch(`${API_BASE_URL}/members/login`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, password }),
+      });
+
+      let data = null;
+      let text = "";
+
+      const contentType = res.headers.get("content-type") || "";
+      if (contentType.includes("application/json")) {
+        data = await res.json().catch(() => null);
+      } else {
+        text = await res.text().catch(() => "");
+      }
+
+      if (!res.ok) {
+        const msg = (data && data.message) || text || "로그인 실패";
+        throw new Error(msg);
+      }
+
+      if (data) {
+        localStorage.setItem("user", JSON.stringify(data));
+      }
+
+      navigate("/");
+    } catch (err) {
+      setErrorMsg(err?.message || "로그인 중 오류가 발생했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <div>
-      <h1>로그인 페이지</h1>
-      {/* TODO: 로그인 폼 입력값을 BE /members/login 엔드포인트로 전송 (POST) */}
-      {/* TODO: 로그인 성공 시, 토큰/유저 정보 저장 및 메인 페이지 이동 (BE 연동 필요) */}
+    <div className="auth-container">
+      <h1 className="auth-title">로그인</h1>
+
+      <form onSubmit={handleSubmit} className="auth-form">
+        <label className="auth-label">
+          이메일
+          <input
+            className="auth-input"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="email@example.com"
+            autoComplete="email"
+            disabled={loading}
+          />
+        </label>
+
+        <label className="auth-label">
+          비밀번호
+          <input
+            className="auth-input"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="비밀번호 입력"
+            autoComplete="current-password"
+            disabled={loading}
+          />
+        </label>
+
+        {errorMsg && <p className="auth-msg-error">{errorMsg}</p>}
+
+        <div className="auth-actions">
+          <button className="auth-button" type="submit" disabled={loading}>
+            {loading ? "로그인 중.." : "로그인"}
+          </button>
+
+          <button
+            className="auth-button"
+            type="button"
+            onClick={() => navigate("/register")}
+            disabled={loading}
+          >
+            회원가입
+          </button>
+          <button
+            className="auth-button"
+            type="button"
+            onClick={() => navigate("/")}
+          >
+            메인으로 돌아가기
+          </button>
+        </div>
+      </form>
     </div>
   );
 }

--- a/FE/src/pages/MainPage.jsx
+++ b/FE/src/pages/MainPage.jsx
@@ -1,17 +1,60 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
+import React, { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 
 function MainPage() {
+  const navigate = useNavigate();
+  const [user, setUser] = useState(null);
+
+  // 페이지 들어올 때 localStorage에서 로그인 정보 가져오기
+  useEffect(() => {
+    const saved = localStorage.getItem("user");
+    if (saved) {
+      try {
+        setUser(JSON.parse(saved));
+      } catch {
+        setUser(null);
+      }
+    }
+  }, []);
+
+  // 로그아웃
+  const handleLogout = () => {
+    localStorage.removeItem("user");
+    setUser(null);
+    navigate("/login");
+  };
+
   return (
-    <div>
+    <div style={{ maxWidth: 520, margin: "40px auto", padding: 16 }}>
       <h1>메인 페이지</h1>
-      {/* TODO: 로그인/회원가입 성공 시, 사용자 정보 받아오기 (BE 연동 필요) */}
-      <Link to="/login">
-        <button>로그인</button>
-      </Link>
-      <Link to="/register">
-        <button>회원가입</button>
-      </Link>
+
+      {user ? (
+        <>
+          <p style={{ marginTop: 10 }}>
+            <b>{user.name}</b>님 환영합니다!
+          </p>
+          <button onClick={handleLogout} style={{ marginTop: 16, padding: 12 }}>
+            로그아웃
+          </button>
+        </>
+      ) : (
+        <>
+          
+          <div style={{ display: "flex", gap: 10, marginTop: 16 }}>
+            <Link to="/login">
+              <button style={{ padding: 12 }}>로그인</button>
+            </Link>
+
+            <Link to="/register">
+              <button style={{ padding: 12 }}>회원가입</button>
+            </Link>
+          </div>
+          <p style={{ marginTop: 10, color: "#666" }}>
+            로그인 후 서비스를 이용할 수 있습니다.
+          </p>
+
+        </>
+      )}
     </div>
   );
 }

--- a/FE/src/pages/RegisterPage.jsx
+++ b/FE/src/pages/RegisterPage.jsx
@@ -1,11 +1,163 @@
-import React from 'react';
+import React, { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import "./auth.css";
+
+const API_BASE_URL = "http://localhost:8080";
 
 function RegisterPage() {
+  const navigate = useNavigate();
+
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [password, setPassword] = useState("");
+  const [password2, setPassword2] = useState("");
+
+  const [loading, setLoading] = useState(false);
+  const [errorMsg, setErrorMsg] = useState("");
+  const [successMsg, setSuccessMsg] = useState("");
+  const [isRegistered, setIsRegistered] = useState(false);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setErrorMsg("");
+    setSuccessMsg("");
+
+    if (!email.trim() || !name.trim() || !password.trim() || !password2.trim()) {
+      setErrorMsg("이메일, 이름, 비밀번호를 입력해주세요.");
+      return;
+    }
+    if (name.length > 20) {
+      setErrorMsg("이름은 20자 이하로 입력해주세요.");
+      return;
+    }
+    if (password.length < 8) {
+      setErrorMsg("비밀번호는 8자 이상으로 입력해주세요.");
+      return;
+    }
+    if (password !== password2) {
+      setErrorMsg("비밀번호를 다시 확인해주세요.");
+      return;
+    }
+
+    try {
+      setLoading(true);
+
+      const res = await fetch(`${API_BASE_URL}/members/register`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email, name, password }),
+      });
+
+      const text = await res.text().catch(() => "");
+
+      if (!res.ok) {
+        let msg = text;
+        try {
+          const json = JSON.parse(text);
+          msg = json?.message || msg;
+        } catch {}
+        throw new Error(msg || "회원가입 실패");
+      }
+
+      setSuccessMsg(text || "회원가입이 성공했습니다.");
+      setIsRegistered(true);
+    } catch (err) {
+      setErrorMsg(err?.message || "오류가 발생했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
-    <div>
-      <h1>회원가입 페이지</h1>
-      {/* TODO: 회원가입 폼 입력값을 BE /members/register 엔드포인트로 전송 (POST) */}
-      {/* TODO: 회원가입 성공 시, 로그인 페이지로 이동 (BE 연동 필요) */}
+    <div className="auth-container">
+      <h1 className="auth-title">회원가입</h1>
+
+      {!isRegistered ? (
+        <form onSubmit={handleSubmit} className="auth-form">
+          <label className="auth-label">
+            이메일
+            <input
+              className="auth-input"
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="email@example.com"
+              autoComplete="email"
+              disabled={loading}
+            />
+          </label>
+
+          <label className="auth-label">
+            이름
+            <input
+              className="auth-input"
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="1~20자"
+              maxLength={20}
+              autoComplete="name"
+              disabled={loading}
+            />
+          </label>
+
+          <label className="auth-label">
+            비밀번호
+            <input
+              className="auth-input"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="8자 이상"
+              autoComplete="new-password"
+              disabled={loading}
+            />
+          </label>
+
+          <label className="auth-label">
+            비밀번호 확인
+            <input
+              className="auth-input"
+              type="password"
+              value={password2}
+              onChange={(e) => setPassword2(e.target.value)}
+              placeholder="비밀번호 확인"
+              autoComplete="new-password"
+              disabled={loading}
+            />
+          </label>
+
+          {errorMsg && <p className="auth-msg-error">{errorMsg}</p>}
+          {successMsg && <p className="auth-msg-success">{successMsg}</p>}
+
+          <div className="auth-actions">
+            <button className="auth-button" type="submit" disabled={loading}>
+              {loading ? "가입중.." : "회원가입"}
+            </button>
+
+            <button
+              className="auth-button"
+              type="button"
+              onClick={() => navigate("/")}
+              disabled={loading}
+            >
+              메인으로 돌아가기
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="auth-actions">
+          <p className="auth-msg-success">{successMsg || "회원가입이 성공했습니다."}</p>
+
+          <button className="auth-button" type="button" onClick={() => navigate("/login")}>
+            로그인하러가기
+          </button>
+
+          <button className="auth-button" type="button" onClick={() => navigate("/")}>
+            메인으로 돌아가기
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/FE/src/pages/auth.css
+++ b/FE/src/pages/auth.css
@@ -1,0 +1,44 @@
+.auth-container {
+  max-width: 420px;
+  margin: 40px auto;
+  padding: 16px;
+}
+
+.auth-title {
+  margin: 0 0 16px;
+}
+
+.auth-form {
+  display: grid;
+  gap: 12px;
+}
+
+.auth-label {
+  display: grid;
+  gap: 6px;
+}
+
+.auth-input {
+  width: 100%;
+  padding: 10px;
+  box-sizing: border-box;
+}
+
+.auth-msg-error {
+  color: red;
+  margin: 0;
+}
+
+.auth-msg-success {
+  color: green;
+  margin: 0;
+}
+
+.auth-actions {
+  display: grid;
+  gap: 10px;
+}
+
+.auth-button {
+  padding: 12px;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #11 

## #️⃣ 작업 내용

1.  회원가입 페이지 
- 가입 성공 시 메시지 표시 후 버튼을 눌러 로그인 화면으로 이동
2. 로그인 페이지
- 로그인 성공 시 버튼을 눌러 메인 페이지로 이동
3. 메인 페이지
- 로그인 성공 시 화면에 표시 
4. auth.css로 로그인/회원가입 페이지의 공통 스타일 분리 
5. CORS 설정 추가 

## 논의하고 싶은 부분 (선택)
> 백엔드에 토큰이 없어서 토큰 기반 인증은 추가 못했습니다. 토큰 추가 되면 인증 기능 추가 하겠습니다. 
## 참고사항
 > 서버 연결 할 때 CORS 오류가 떠서 BE의 SecurityConfig.java 에 CORS 설정을 추가했습니다. 팀원들마다 프론트 포트가 달라 질 경우도 있어 http://localhost:* 로 설정하여 포트가 달라도 접속할 수 있게 수정했습니다. (만약 5173 포트만 허용하고 싶다면 http://localhost:5173 으로 수정하면 됩니다)
